### PR TITLE
Add Plausible analytics tracking snippet

### DIFF
--- a/card.html
+++ b/card.html
@@ -7,6 +7,13 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
     <title>Emre Sokullu</title>
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-yCMX83LNFSaT7_72ZFA2A.js"></script>
+    <script>
+      window.plausible = window.plausible || function(){(plausible.q = plausible.q || []).push(arguments)};
+      plausible.init = plausible.init || function(i){plausible.o = i || {}};
+      plausible.init();
+    </script>
     <style>
         .section {
             padding: 1em; 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
     <title>Emre Sokullu</title>
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-yCMX83LNFSaT7_72ZFA2A.js"></script>
+    <script>
+      window.plausible = window.plausible || function(){(plausible.q = plausible.q || []).push(arguments)};
+      plausible.init = plausible.init || function(i){plausible.o = i || {}};
+      plausible.init();
+    </script>
     <style>
         .section {
             padding: 1em; 


### PR DESCRIPTION
### Motivation
- Add a lightweight, privacy-friendly analytics solution to the site so page views can be collected without invasive tracking.

### Description
- Inserted the Plausible loader and `plausible.init()` snippet into the `<head>` of both `index.html` and `card.html` to enable consistent analytics across pages.

### Testing
- Verified the snippet is present in both files by running `rg -n "Privacy-friendly analytics by Plausible|plausible.init\(\)" index.html card.html` and inspected the file headers with `nl -ba index.html card.html | sed -n '1,35p'`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd5618bc8c8327a36879f5157f91cb)