### PR TITLE
Add Turkix link to Past section

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
                 <h3>Past</h3>
                 <a href="#" data-container="body" data-toggle="popover" data-placement="right" data-content="The first DIY social network platform. Founded in 2005. Exited in 2018 to a public telecom corporation." class="p-experience">Grou.ps</a><br>
                 <a href="#" data-container="body" data-toggle="popover" data-placement="right" data-content="Developer Tools for Social Networking. Founded in 2019, exited in 2021 to Rock Content." class="p-experience">Research in Social Graph (GraphJS)</a><br>
+                <a href="https://turkix.com" class="p-experience">Turkix</a><br>
             </div>
             <div class="content section d-none">
                 <h3>Investments</h3>


### PR DESCRIPTION
### Motivation
- Add `Turkix` to the personal site Past section so the site lists this past project and links to `https://turkix.com`.

### Description
- Inserted `<a href="https://turkix.com" class="p-experience">Turkix</a><br>` into `index.html` as the last item under the `Past` section and committed the change with message `Add Turkix to Past links`.

### Testing
- No automated tests were required for this content-only HTML update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc547ceb4c832796da0b13864f5a5f)