### PR TITLE
Expose external links for past projects and add Turkix to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,8 +232,9 @@
                 </div>
                 <div class="content section">
                 <h3>Past</h3>
-                <a href="#" data-container="body" data-toggle="popover" data-placement="right" data-content="The first DIY social network platform. Founded in 2005. Exited in 2018 to a public telecom corporation." class="p-experience">Grou.ps</a><br>
-                <a href="#" data-container="body" data-toggle="popover" data-placement="right" data-content="Developer Tools for Social Networking. Founded in 2019, exited in 2021 to Rock Content." class="p-experience">Research in Social Graph (GraphJS)</a><br>
+                <a href="http://grou.ps" data-container="body" data-toggle="popover" data-placement="right" data-content="The first DIY social network platform. Founded in 2005. Exited in 2018 to a public telecom corporation." class="p-experience">Grou.ps</a><br>
+                <a href="https://github.com/graphjs/graphjs" data-container="body" data-toggle="popover" data-placement="right" data-content="Developer Tools for Social Networking. Founded in 2019, exited in 2021 to Rock Content." class="p-experience">Research in Social Graph (GraphJS)</a><br>
+                <a href="https://turkix.com" class="p-experience">Turkix</a><br>
             </div>
             <div class="content section d-none">
                 <h3>Investments</h3>


### PR DESCRIPTION
### Motivation
- Replace placeholder/popover-only entries in the "Past" section with direct external links so visitors can navigate to project pages and add a missing project reference.

### Description
- Updated the "Past" anchors in `index.html` to point to `http://grou.ps` and `https://github.com/graphjs/graphjs` and added a new `Turkix` link to the same section.

### Testing
- Ran an HTML validation check on `index.html` (using `tidy`) against the updated file and it passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc547ceb4c832796da0b13864f5a5f)