### PR TITLE
Add non-profit badge for MastoTurk in Work section

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
               -->
               <a href="https://miras.global">miras.global</a> <br>
               <a href="https://securebtcwallet.com">SecureBtcWallet</a> <br>
-              <a href="https://mastoturk.org">MastoTurk</a> <br>
+              <a href="https://mastoturk.org">MastoTurk</a> <span class="badge badge-success">non-profit</span><br>
               <a href="https://phonetworks.com">Phở Networks</a> <span class="badge badge-success">non-profit</span> <!--<span class="badge badge-warning">dormant</span>--><br>
               and more...<br>
                 </div>


### PR DESCRIPTION
### Motivation
- Mark MastoTurk as a non-profit in the main Work list to match the existing badge usage elsewhere on the site.

### Description
- Update `index.html` to add `<span class="badge badge-success">non-profit</span>` next to the MastoTurk link in the Work section.

### Testing
- No automated tests were run (static HTML change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc65f895288327bed70149da96ab83)