### PR TITLE
Improve mobile layout and fix malformed heading markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
         /* Mobile Styles */
         @media (max-width: 767px) {
           .right-block {
-            background-attachment: fixed;
-            min-height: 300px; /* Adjust as needed */
+            background-attachment: scroll;
+            min-height: 38vh;
           }
             .right-column {
                 text-align: center; 
@@ -48,6 +48,15 @@
             }
           #personal-card {
             padding-bottom: 2em;
+          }
+          .section {
+            padding: 0.75em 1em;
+          }
+          .content.section h3 {
+            margin-bottom: 0.5rem;
+          }
+          .content.section a {
+            word-break: break-word;
           }
         }
 
@@ -93,7 +102,7 @@
 }
 #emrebot-bar button:hover{background:#005ecb}
 @media(max-width:767.98px){
-  #emrebot-bar{bottom:auto;top:12px;left:12px;right:12px;width:auto}
+  #emrebot-bar{position:sticky;top:0;left:0;right:0;bottom:auto;width:100%;padding:8px 12px;z-index:1030}
   #emrebot-bar-form{
     background:rgba(255,255,255,.95);
     backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);
@@ -211,8 +220,8 @@
 
   </head>
   <body class="h-card h-resume">
-    <div class="container-fluid">
-      <div class="row" style="min-height: 100vh">
+    <div class="container-fluid px-0 px-md-3">
+      <div class="row no-gutters" style="min-height: 100vh">
         <div class="col-lg-6 col-md-6 col-sm-12 order-2 order-md-1" style="background-color: #f2f2f2;">
             <div class="content section">
                 <h3>Books</h3>
@@ -250,7 +259,7 @@
             </div>
 
           <div class="content section">
-                <h3>Associations</h3
+                <h3>Associations</h3>
                 <a data-container="body" data-toggle="popover" data-placement="top" data-content="Galatasaray SK Congressmember" href="https://www.galatasaray.org/" target="_blank"><img src="galatasaray.png" style="width:60px; height: 80px;"></a> <a data-container="body" data-toggle="popover" data-placement="top" data-content="Bogazici University" href="https://bogazici.edu.tr/" target="_blank"><img src="bogazici.png" style="width:80px; height: 80px;"></a> </div>
         </div>
         <div class="col-lg-6 col-md-6 col-sm-12 order-1 order-md-2 right-block" style="padding-right: 0; padding-left: 0;">


### PR DESCRIPTION
### Motivation
- Mobile rendering was poor due to a fixed background, cramped layout and a malformed HTML tag causing unpredictable DOM/layout behavior.
- The chat input and container spacing crowded content on small screens, reducing readability and usability.

### Description
- Replaced `background-attachment: fixed` with `background-attachment: scroll` and reduced the hero block height on small screens (`min-height: 38vh`) in `index.html` to avoid mobile jank.
- Tightened mobile spacing by adjusting `.section` padding and headline rhythm and enabled long-link wrapping with `word-break: break-word` for better small-screen readability.
- Changed the mobile chat bar behavior from a floating box to a full-width sticky top bar (`position: sticky`) with safe padding to avoid overlapping content.
- Fixed malformed heading markup by closing the `Associations` `<h3>` tag and adjusted the Bootstrap wrapper to `container-fluid px-0 px-md-3` and `row no-gutters` to remove unwanted mobile side gutters.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1388bcd7e48327822c67a642a9c3db)