### PR TITLE
Replace Turkish flag emoji with elephant for MastoTurk links

### DIFF
--- a/card.html
+++ b/card.html
@@ -106,7 +106,7 @@
                 
                     <p id="personal-card">
                         <a href="https://mstdn.social/@esokullu" rel="me" class="text-white u-url">@esokullu@mstdn.social</a> 🇺🇸 <br/>
-                        <a href="https://mastoturk.org/@esokullu" rel="me" class="text-white u-url">@esokullu@mastoturk.org</a> 🇹🇷 <br/>
+                        <a href="https://mastoturk.org/@esokullu" rel="me" class="text-white u-url">@esokullu@mastoturk.org</a> 🐘 <br/>
                         <a href="/myblog" rel="me" class="text-white u-url">Blog</a> ✏️ <br/>
                       <a href="https://github.com/esokullu" rel="me" class="text-white u-url">https://github.com/esokullu</a> 👨‍💻 <br/>
                         <a href="mailto:esokullu@gmail.com" class="text-white p-contact">esokullu@gmail.com</a> ✉️

--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
                       <!--
                         <a href="https://mstdn.social/@esokullu" rel="me" class="text-white u-url">@esokullu@mstdn.social</a> 🇺🇸 <br/>
                       -->
-                        <a href="https://mastoturk.org/@esokullu" rel="me" class="text-white u-url">@esokullu@mastoturk.org</a> 🇹🇷 <br/>
+                        <a href="https://mastoturk.org/@esokullu" rel="me" class="text-white u-url">@esokullu@mastoturk.org</a> 🐘 <br/>
                         
                        
                       <a href="https://github.com/esokullu" rel="me" class="text-white u-url">https://github.com/esokullu</a> 👨‍💻 <br/>


### PR DESCRIPTION
### Motivation
- Replace the Turkish flag emoji with an elephant emoji next to the MastoTurk profile links to update the displayed symbol and keep profile views consistent.

### Description
- Replaced `🇹🇷` with `🐘` in the `@esokullu@mastoturk.org` profile link occurrences in `index.html` and `card.html`.

### Testing
- No automated tests were run for this content-only HTML emoji update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1508ca21448327a960d2a52c25db9d)